### PR TITLE
Feature/add faraday encoding middleware and db transaction check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ doc/
 pkg/
 *.db
 tmp/
+.ruby-version

--- a/lib/faraday_middleware/encoding.rb
+++ b/lib/faraday_middleware/encoding.rb
@@ -9,7 +9,7 @@ module Faraday
         @content_charset = nil
         if /;\s*charset=\s*(.+?)\s*(;|$)/.match(env[:response_headers][:content_type])
           encoding = $1
-          encoding = 'utf-8' if encoding == 'utf8'
+          encoding = 'utf-8' if encoding == 'utf8' # this is the actual fix
           @content_charset = ::Encoding.find encoding rescue nil
         end
         env[:body].force_encoding @content_charset if @content_charset

--- a/lib/webhook_system.rb
+++ b/lib/webhook_system.rb
@@ -4,6 +4,7 @@ require 'active_job'
 require 'ph_model'
 require 'validate_url'
 require 'faraday'
+require 'webhook_system/faraday_middleware/encoding'
 
 module WebhookSystem
   extend ActiveSupport::Autoload

--- a/lib/webhook_system.rb
+++ b/lib/webhook_system.rb
@@ -4,7 +4,7 @@ require 'active_job'
 require 'ph_model'
 require 'validate_url'
 require 'faraday'
-require 'webhook_system/faraday_middleware/encoding'
+require 'faraday_middleware/encoding'
 
 module WebhookSystem
   extend ActiveSupport::Autoload

--- a/lib/webhook_system/event_log.rb
+++ b/lib/webhook_system/event_log.rb
@@ -4,6 +4,8 @@ module WebhookSystem
   class EventLog < ActiveRecord::Base
     self.table_name = 'webhook_event_logs'
 
+    MAX_JSON_ATTRIBUTE_SIZE = 40_000
+
     belongs_to :subscription, class_name: 'WebhookSystem::Subscription'
 
     validates :event_id, presence: true
@@ -18,12 +20,12 @@ module WebhookSystem
       request_info = {
         'event' => event,
         'headers' => request.headers.to_hash,
-        'body' => request.body,
+        'body' => request.body.truncate(MAX_JSON_ATTRIBUTE_SIZE),
         'url' => request.path,
       }
       response_info = {
         'headers' => response.headers.to_hash,
-        'body' => response.body,
+        'body' => response.body.truncate(MAX_JSON_ATTRIBUTE_SIZE),
       }
 
       attributes = {

--- a/lib/webhook_system/faraday_middleware/encoding.rb
+++ b/lib/webhook_system/faraday_middleware/encoding.rb
@@ -1,0 +1,21 @@
+# This is taken from https://github.com/ma2gedev/faraday-encoding,
+# all credits for this goes to Takayuki Matsubara (takayuki.1229+github@gmail.com).
+# We should be able to switch to the original gem when
+# this PR (https://github.com/ma2gedev/faraday-encoding/pull/2) is merged.
+module Faraday
+  class Faraday::Encoding < Faraday::Middleware
+    def call(environment)
+      @app.call(environment).on_complete do |env|
+        @content_charset = nil
+        if /;\s*charset=\s*(.+?)\s*(;|$)/.match(env[:response_headers][:content_type])
+          encoding = $1
+          encoding = 'utf-8' if encoding == 'utf8'
+          @content_charset = ::Encoding.find encoding rescue nil
+        end
+        env[:body].force_encoding @content_charset if @content_charset
+      end
+    end
+  end
+end
+
+Faraday::Response.register_middleware :encoding => Faraday::Encoding

--- a/lib/webhook_system/job.rb
+++ b/lib/webhook_system/job.rb
@@ -51,14 +51,14 @@ module WebhookSystem
       if ActiveRecord::Base.connection.open_transactions == 0
         event_log.save!
       else
-        Thread.new { event_log.save! }
+        Thread.new { event_log.save! }.join
       end
     end
 
     def self.build_client
       Faraday.new do |faraday|
         faraday.response :logger if ENV['WEBHOOK_DEBUG']
-        # use Faraday::Encoding middleware, lib/webhook_system/faraday_middleware/encoding.rb
+        # use Faraday::Encoding middleware, libfaraday_middleware/encoding.rb
         faraday.response :encoding
         faraday.adapter Faraday.default_adapter
       end

--- a/spec/event_log_spec.rb
+++ b/spec/event_log_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe WebhookSystem::EventLog, db: true do
+  let(:subscription_id) { 1 }
+  let(:event_id) { 2 }
+  let(:event_name) { 'do_something' }
+  let(:status) { 200 }
+  let(:request) { {} }
+  let(:response) { {} }
+
+  context 'validations' do
+    subject(:log) do
+      build :webhook_event_log,
+            subscription_id: subscription_id,
+            event_id: event_id,
+            event_name: event_name,
+            status: status,
+            request: request,
+            response: response
+    end
+
+    it 'is valid' do
+      expect(subject).to be_valid
+    end
+
+    context 'event_id' do
+      let(:event_id) { nil }
+
+      it 'validates presence of event_id' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'subscription_id' do
+      let(:subscription_id) { nil }
+
+      it 'validates presence of subscription_id' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'event_name' do
+      let(:event_name) { nil }
+
+      it 'validates presence of event_name' do
+        expect(subject).to_not be_valid
+      end
+    end
+
+    context 'status' do
+      let(:status) { nil }
+
+      it 'validates presence of status' do
+        expect(subject).to_not be_valid
+      end
+    end
+  end
+
+  context '#construct' do
+    let(:subscription) { create :webhook_subscription }
+    let(:event) { { 'event_name' => event_name, 'event_id' => event_id } }
+    let(:request) { double(:request, headers: {}, body: 'a' * 64_000, path: 'url') }
+    let(:response) { double(:request, headers: {}, body: 'b' * 64_000, status: status) }
+
+    subject(:log) do
+      WebhookSystem::EventLog.construct(subscription, event, request, response)
+    end
+
+    context 'request/response body is bigger than 60K' do
+      it 'truncates request body to 60K' do
+        subject.save!
+        expect(subject.request['body'].length).to eq(40_000)
+      end
+
+      it 'truncates response body to 60K' do
+        subject.save!
+        expect(subject.response['body'].length).to eq(40_000)
+      end
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,4 +1,13 @@
 FactoryGirl.define do
+  factory :webhook_event_log, class: WebhookSystem::EventLog do
+    event_id 1
+    subscription_id 1
+    event_name 'do_something'
+    status 200
+    request { { 'event' => 'body' } }
+    response { { 'body' => 'ok' } }
+  end
+
   factory :webhook_subscription, class: WebhookSystem::Subscription do
     url 'http://lvh.me/webhook'
     secret 'some-secret'

--- a/webhook_system.gemspec
+++ b/webhook_system.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activesupport', '> 3.2'
   gem.add_runtime_dependency 'activerecord', '> 3.2'
   gem.add_runtime_dependency 'activejob'
-  gem.add_runtime_dependency 'faraday'
+  gem.add_runtime_dependency 'faraday', '~> 0.9'
   gem.add_runtime_dependency 'ph_model'
   gem.add_runtime_dependency 'validate_url', '~> 1.0'
 


### PR DESCRIPTION
**Feature:**
Add a Faraday middleware to correctly parse and set response encoding based on the content type headers.
Make sure we always save EventLog, even if we are in the Job that fails and all DB changes are suppose to be rollbacked.

**Ticket:**
https://payrollhero5161.leankit.com/Boards/View/253241089/293211322/299717843

**Submitter Checklist:**
- [ ] CI Passing
- [ ] PR Linked to Asana Ticket
- [ ] Hound Appeased Acceptably
- [ ] No Code Climate Issues
- [ ] Class, Module, and public method comments up to spec

**Reviewer Checklist:**
- [ ] New Code Tested Effectively
- [ ] Code organization meets SOP standards
- [ ] Does this code fulfill the ticket?

**Only Then:**
- [ ] Move ticket in LeanKit